### PR TITLE
Fix iOS statusbar

### DIFF
--- a/src/build/template.html
+++ b/src/build/template.html
@@ -17,6 +17,7 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="{intl.appName}" >
   <meta name="apple-mobile-web-app-status-bar-style" content="default" >
+  <meta name="theme-color" content="#4169e1" >
 
   <!-- inline CSS -->
 


### PR DESCRIPTION
It'll fix statusbar going white. 

I assume that theme-color meta tag is what decides the status bar color in ios, accoring to https://github.com/baggachipz/tinylist/blob/a069b893155bf4c60ba0c4812700230019ff739b/src/index.template.html#L11.

This app also applied the same patch, and its status bar works.